### PR TITLE
Minor: add .gitignore rules for easier mod-dev

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 game/images/
 game/videos/
 game/saves/
+game/mods/*
+!game/mods/CheatMod
 game/cache/
 **.rpy.bak
 **.bak


### PR DESCRIPTION
Include a ignore rule on the mods folder so that mods do not get checked out in the main repo. this makes mod-work easier since i don't have to handle two seperate repos then. Also added the exclusion rule on the base CheatMod so that changes on it are checked in with the base game (as i assume it will always be shipped with the game).