### PR TITLE
Minor: fix scoping issue inside DaytimeChangedCondition

### DIFF
--- a/game/scripts/conditions.rpy
+++ b/game/scripts/conditions.rpy
@@ -3785,6 +3785,8 @@ init -6 python:
             super().__init__(False, *options)
 
         def check_condition(self, **kwargs) -> bool:
+            global last_daytime
+            
             if last_daytime == None or last_daytime != time.now():
                 last_daytime = time.now()
                 return True


### PR DESCRIPTION
Given you have added a lot of new Game Logic i assume you already now about this ;)
It causes an error on game start and made testing my mod event difficult - so here i am pestering you with a PR again :D

This is just so the Python Runtime doesn't get confused on the variables locality since without it, it throws
UnboundLocalError: local variable 'last_daytime' referenced before assignment at line 3788